### PR TITLE
update to version 1.2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,13 @@ LABEL maintainer="alexandregv <contact@alexandregv.fr>"
 LABEL description="Paheko dockerized, with built-in nginx."
 LABEL url="https://github.com/alexandregv/garrad2"
 
+# Install php extensions
+RUN apt-get -y update \
+ && apt-get install -y libicu-dev \
+ && docker-php-ext-configure intl \
+ && docker-php-ext-install intl
+ && rm -rf /var/lib/apt/lists/*
+
 # Set the paheko version
 ENV PAHEKO_VERSION 1.2.7
 
@@ -33,11 +40,6 @@ RUN curl -L -O https://fossil.kd2.org/paheko/uv/paheko-$PAHEKO_VERSION.tar.gz \
  && tar xf paheko-$PAHEKO_VERSION.tar.gz -C . --strip-components=1 \
  && rm -r paheko-$PAHEKO_VERSION.tar.gz \
  && chown -R www-data:www-data .
-
-RUN apt-get -y update \
- && apt-get install -y libicu-dev \
- && docker-php-ext-configure intl \
- && docker-php-ext-install intl
 
 # Download and install paheko plugins
 RUN cd ./data/plugins \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL description="Paheko dockerized, with built-in nginx."
 LABEL url="https://github.com/alexandregv/garrad2"
 
 # Set the paheko version
-ENV PAHEKO_VERSION 1.2.6
+ENV PAHEKO_VERSION 1.2.7
 
 # Set the timezone
 ENV TZ UTC
@@ -33,6 +33,11 @@ RUN curl -L -O https://fossil.kd2.org/paheko/uv/paheko-$PAHEKO_VERSION.tar.gz \
  && tar xf paheko-$PAHEKO_VERSION.tar.gz -C . --strip-components=1 \
  && rm -r paheko-$PAHEKO_VERSION.tar.gz \
  && chown -R www-data:www-data .
+
+RUN apt-get -y update \
+ && apt-get install -y libicu-dev \
+ && docker-php-ext-configure intl \
+ && docker-php-ext-install intl
 
 # Download and install paheko plugins
 RUN cd ./data/plugins \


### PR DESCRIPTION
Changes in Dockerfile for update 1.2.7 of paheko :
- change version 1.2.6 to 1.2.7
- command to install intl php extension in Dockerfile was needed for version 1.2.7 of Paheko