### PR TITLE
upgrading Paheko in 1.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get -y update \
  && rm -rf /var/lib/apt/lists/*
 
 # Set the paheko version
-ENV PAHEKO_VERSION 1.2.7
+ENV PAHEKO_VERSION 1.3.2
 
 # Set the timezone
 ENV TZ UTC

--- a/config.local.php
+++ b/config.local.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Garradin;
+namespace Paheko;
 
 // Your custom domain url. MUST end with a '/'. Use it to force HTTPS or custom domain.
 //const WWW_URL = 'https://paheko.chezmoi.tld/';


### PR DESCRIPTION
Paheko in version 1.3.2

- Upgrading `PAHEKO_VERSION` in Dockerfile from 1.2.7 to 1.3.2

- changed namespace in `config.local.php` from Garradin to Paheko to match requirements of version 1.3.0
